### PR TITLE
Fix a small bug in DALLE Class

### DIFF
--- a/dalle_pytorch/dalle_pytorch.py
+++ b/dalle_pytorch/dalle_pytorch.py
@@ -156,9 +156,10 @@ class DALLE(nn.Module):
         self.num_text_tokens = num_text_tokens # for offsetting logits index and calculating cross entropy loss
         self.image_seq_len = image_seq_len
         self.total_tokens = num_text_tokens + num_image_tokens + 1 # extra for EOS
-
-        self.vae = vae
-        self.image_emb = vae.codebook
+        
+        if self.vae is not None:
+            self.vae = vae
+            self.image_emb = vae.codebook
         self.transformer = Decoder(dim = dim, depth = depth, heads = heads)
 
         self.to_logits = nn.Sequential(


### PR DESCRIPTION
- image_emb is getting overridden which shouldn't be the case when 'vae' parameter is not passed or is None.