### PR TITLE
implement number of layers logic for discrete VAE

### DIFF
--- a/dalle_pytorch/dalle_pytorch.py
+++ b/dalle_pytorch/dalle_pytorch.py
@@ -88,7 +88,6 @@ class DiscreteVAE(nn.Module):
         decoder_layers = []
         for i in range(num_layers):
             enc_in = 3 if i == 0 else hdim
-            dec_in = dim if i == 0 else hdim
             encoder_layers += [
                 nn.Conv2d(enc_in, hdim, 4, stride = 2, padding = 1),
                 nn.ReLU(),


### PR DESCRIPTION
I need to convert 128x128 images to 32x32 representation - for that using `num_layers=2` will work. with `num_layers=4` one can convert 512x512 images to 32x32 codebook.