### PR TITLE
add sparse attention to DALL-E

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,36 @@ dalle = DALLE(
 )
 ```
 
+## Sparse Attention
+
+You can also train with Microsoft Deepspeed's Sparse Attention, with any combination of dense and sparse attention that you'd like. However, you will have to endure the installation process.
+
+First, you need to install Deepspeed with Sparse Attention
+
+```bash
+$ sh install_deepspeed.sh
+```
+
+Next, you need to install the pip package `triton`
+
+```bash
+$ pip install triton
+```
+
+If both of the above succeeded, now you can train with Sparse Attention!
+
+```python
+dalle = DALLE(
+    dim = 512,
+    vae = vae,
+    num_text_tokens = 10000,
+    text_seq_len = 256,
+    depth = 64,
+    heads = 8,
+    sparse_attn = (True, False) * 32  # interleave sparse and dense attention for 64 layers
+)
+```
+
 ## Citations
 
 ```bibtex

--- a/install_deepspeed.sh
+++ b/install_deepspeed.sh
@@ -1,0 +1,3 @@
+sudo apt-get -y install llvm-9-dev cmake
+git clone https://github.com/microsoft/DeepSpeed.git /tmp/Deepspeed
+cd /tmp/Deepspeed && DS_BUILD_SPARSE_ATTN=1 ./install.sh -s

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
   name = 'dalle-pytorch',
   packages = find_packages(),
-  version = '0.0.35',
+  version = '0.0.36',
   license='MIT',
   description = 'DALL-E - Pytorch',
   author = 'Phil Wang',


### PR DESCRIPTION
Add ability to specify at which layers to use Deepspeed's Sparse Attention

https://www.deepspeed.ai/news/2020/09/08/sparse-attention.html

todo - handle padding to block size for generation
todo - see if some kernels allow for specifying global attention tokens on the left (for text)