### PR TITLE
Avoid errors with lengthy captions

### DIFF
--- a/train_dalle.py
+++ b/train_dalle.py
@@ -166,7 +166,8 @@ class TextImageDataset(Dataset):
         descriptions = text_file.read_text().split('\n')
         descriptions = list(filter(lambda t: len(t) > 0, descriptions))
         description = choice(descriptions)
-
+        description = " ".join(description.split(" ")[:TEXT_SEQ_LEN-1]) # Trim captions longer than TOKEN_LENGTH
+        
         tokenized_text = tokenize(description).squeeze(0)
         mask = tokenized_text != 0
 


### PR DESCRIPTION
Was training on OpenImagesV6 last night and they have a few captions that are more than 256 tokens in length. This (of course) throws an exception which interrupts training and what-not. 

There's probably an argument to be made that you would just want to throw these out altogether, but as it stands I think a trim is a decent enough fix given that's quite a lengthy caption in the first place.