### PR TITLE
Add adamw and lr decay

### DIFF
--- a/train_dalle.py
+++ b/train_dalle.py
@@ -129,6 +129,19 @@ def save_model(path):
 
     torch.save(save_obj, path)
 
+def group_weight(model):
+    group_decay, group_no_decay = [], []
+    for params in model.named_parameters():
+        if 'transformer' in params[0]:
+            if 'bias' in params[0] or 'norm' in params[0]:
+                group_no_decay.append(params[1])
+                continue
+        group_decay.append(params[1])
+
+    assert len(list(model.parameters())) == len(group_decay) + len(group_no_decay)
+    groups = [dict(params=group_decay), dict(params=group_no_decay, weight_decay=.0)]
+    return groups
+
 # dataset loading
 
 class TextImageDataset(Dataset):
@@ -202,7 +215,7 @@ if RESUME:
 # optimizer
 
 if OPTIMIZER is 'adamw':
-    opt = AdamW(dalle.parameters(), lr = LEARNING_RATE, betas = (0.9, 0.96), eps = 1e-08, weight_decay = 4.5e-2, amsgrad = False)
+    opt = AdamW(group_weight(dalle), lr = LEARNING_RATE, betas = (0.9, 0.96), eps = 1e-08, weight_decay = 4.5e-2, amsgrad = False)
 else:
     opt = Adam(dalle.parameters(), lr = LEARNING_RATE)
 

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -253,7 +253,7 @@ for epoch in range(EPOCHS):
                 'epoch': epoch,
                 'iter': i,
                 'loss': loss.item(),
-                'lr': opt.param_groups[0]["lr"].item()*100
+                'lr': opt.param_groups[0]["lr"]
             }
 
         if i % 100 == 0:


### PR DESCRIPTION
This commit adds AdamW optimizer and LR decay with 'ReduceLROnPlateau' by following the DALLE paper.
In DALLE paper,
![image](https://user-images.githubusercontent.com/12422441/112938980-a7ed4000-9165-11eb-8668-66393511693d.png)
![image](https://user-images.githubusercontent.com/12422441/112938997-ade32100-9165-11eb-8bbc-eaa21f7a0d19.png)
Both AdamW optimizer and LR decay in the code follows the same parameters of the paper.
I found LR decay is helpful as shown in https://github.com/lucidrains/DALLE-pytorch/discussions/131, but AdamW  optimizer is not stable yet.
So, I set both AdamW optimizer and LR decay is optional.
@lucidrains , Please check the code :)