### PR TITLE
Include missing regex dependency in setup py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     'einops>=0.3',
     'ftfy',
     'pillow',
+    'regex',
     'taming-transformers',
     'torch>=1.6',
     'torchvision',


### PR DESCRIPTION
Nothing substantial sorry - just something that's been bugging me. Still working on some of these deepspeed issues however.