### PR TITLE
Clean up VRAM to allow for running on 8xV100

### DIFF
--- a/train_dalle.py
+++ b/train_dalle.py
@@ -221,7 +221,7 @@ if deepspeed_utils.is_root_worker():
 dl = DataLoader(ds, batch_size = BATCH_SIZE, shuffle = True, drop_last = True)
 
 # initialize DALL-E
-
+torch.cuda.empty_cache()
 dalle = DALLE(vae = vae, **dalle_params).cuda()
 
 if RESUME:
@@ -278,7 +278,7 @@ deepspeed_config = {'train_batch_size': BATCH_SIZE}
 )
 
 # training
-
+torch.cuda.empty_cache()
 for epoch in range(EPOCHS):
     for i, (text, images, mask) in enumerate(dl):
         text, images, mask = map(lambda t: t.cuda(), (text, images, mask))
@@ -300,6 +300,7 @@ for epoch in range(EPOCHS):
             opt.zero_grad()
 
         if deepspeed_utils.is_root_worker():
+            torch.cuda.empty_cache()
             log = {}
 
             if i % 10 == 0:


### PR DESCRIPTION
I found that the rank 0 gpu needs to have its cache emptied or it will OOM on more than 4 GPUs in the same instance. This fixes that to a degree - although I'm still working on making sure each of the 8 GPU's is being used effectively - as it stands they can only get to about 10GiB/16GiB vram usage with a batch size of 64 (depth 8, heads 8, attn_types=('sparse'), reversible=False). But this should help at least.