### PR TITLE
Delay requiring DeepSpeed initialization

### DIFF
--- a/dalle_pytorch/deepspeed_utils.py
+++ b/dalle_pytorch/deepspeed_utils.py
@@ -66,20 +66,20 @@ def require_torch_distributed_init():
 
 def get_world_size():
     """Return the amount of distributed processes."""
-    require_init()
     if not using_deepspeed:
         return 1
 
+    require_init()
     require_torch_distributed_init()
     return torch.distributed.get_world_size()
 
 
 def get_rank():
     """Return the global rank of the calling worker process."""
-    require_init()
     if not using_deepspeed:
         return ROOT_RANK
 
+    require_init()
     require_torch_distributed_init()
     return torch.distributed.get_rank()
 
@@ -88,10 +88,10 @@ def get_local_rank():
     """Return the local rank of the calling worker process.
     The local rank is the rank based on a single node's processes.
     """
-    require_init()
     if not using_deepspeed:
         return ROOT_RANK
 
+    require_init()
     require_torch_distributed_init()
     return int(os.environ['LOCAL_RANK'])
 
@@ -112,10 +112,10 @@ def is_local_root_worker():
 
 def local_barrier():
     """Wait until all processes on this node have called this function."""
-    require_init()
     if not using_deepspeed:
         return
 
+    require_init()
     require_torch_distributed_init()
     torch.distributed.barrier()
 
@@ -137,10 +137,10 @@ def maybe_distribute(
     For the other or other possible arguments,
     see `deepspeed.initialize`.
     """
-    require_init()
     if not using_deepspeed:
         return (model, optimizer, training_data, lr_scheduler)
 
+    require_init()
     return deepspeed.initialize(
         args=args,
         model=model,
@@ -160,10 +160,10 @@ def check_batch_size(batch_size):
 
 def average_all(tensor):
     """Return the average of `tensor` over all workers."""
-    require_init()
     if not using_deepspeed:
         return tensor
 
+    require_init()
     require_torch_distributed_init()
     # We copy because modification happens in-place
     averaged = tensor.detach().clone()

--- a/dalle_pytorch/vae.py
+++ b/dalle_pytorch/vae.py
@@ -51,7 +51,7 @@ def unmap_pixels(x, eps = 0.1):
     return torch.clamp((x - eps) / (1 - 2 * eps), 0, 1)
 
 def download(url, filename = None, root = CACHE_PATH):
-    if deepspeed_utils.using_deepspeed and deepspeed_utils.is_local_root_worker():
+    if deepspeed_utils.is_local_root_worker():
         os.makedirs(root, exist_ok = True)
     filename = default(filename, os.path.basename(url))
 
@@ -61,7 +61,7 @@ def download(url, filename = None, root = CACHE_PATH):
     if os.path.exists(download_target) and not os.path.isfile(download_target):
         raise RuntimeError(f"{download_target} exists and is not a regular file")
 
-    if deepspeed_utils.using_deepspeed and not deepspeed_utils.is_local_root_worker() and not os.path.isfile(download_target):
+    if not deepspeed_utils.is_local_root_worker() and not os.path.isfile(download_target):
         # If the file doesn't exist yet, wait until it's downloaded by the root worker.
         deepspeed_utils.local_barrier()
 


### PR DESCRIPTION
This way, we don't require initialization when it's not used.

Fix #165 and partly revert 19d8778 (I don't revert the version number change).