### PR TITLE
Revert delayed DeepSpeed requirement

### DIFF
--- a/dalle_pytorch/deepspeed_utils.py
+++ b/dalle_pytorch/deepspeed_utils.py
@@ -51,8 +51,9 @@ def init_deepspeed(do_init):
 def require_init():
     """Raise an error when DeepSpeed has not been initialized yet."""
     assert using_deepspeed is not None, \
-        ('DeepSpeed has not been initialized; please call '
-         '`deepspeed_utils.init_deepspeed` at the start of your script')
+        ('`deepspeed_utils` have not been initialized; please call '
+         '`deepspeed_utils.init_deepspeed` at the start of your script to '
+         'allow optional DeepSpeed usage')
 
 
 def require_torch_distributed_init():
@@ -60,7 +61,7 @@ def require_torch_distributed_init():
     initialized yet.
     """
     assert torch.distributed.is_initialized(), \
-        ('torch.distributed is not initialized; please call '
+        ('`torch.distributed` is not initialized; please call '
          '`deepspeed_utils.init_deepspeed` at the start of your script')
 
 

--- a/dalle_pytorch/deepspeed_utils.py
+++ b/dalle_pytorch/deepspeed_utils.py
@@ -66,20 +66,20 @@ def require_torch_distributed_init():
 
 def get_world_size():
     """Return the amount of distributed processes."""
+    require_init()
     if not using_deepspeed:
         return 1
 
-    require_init()
     require_torch_distributed_init()
     return torch.distributed.get_world_size()
 
 
 def get_rank():
     """Return the global rank of the calling worker process."""
+    require_init()
     if not using_deepspeed:
         return ROOT_RANK
 
-    require_init()
     require_torch_distributed_init()
     return torch.distributed.get_rank()
 
@@ -88,10 +88,10 @@ def get_local_rank():
     """Return the local rank of the calling worker process.
     The local rank is the rank based on a single node's processes.
     """
+    require_init()
     if not using_deepspeed:
         return ROOT_RANK
 
-    require_init()
     require_torch_distributed_init()
     return int(os.environ['LOCAL_RANK'])
 
@@ -112,10 +112,10 @@ def is_local_root_worker():
 
 def local_barrier():
     """Wait until all processes on this node have called this function."""
+    require_init()
     if not using_deepspeed:
         return
 
-    require_init()
     require_torch_distributed_init()
     torch.distributed.barrier()
 
@@ -137,10 +137,10 @@ def maybe_distribute(
     For the other or other possible arguments,
     see `deepspeed.initialize`.
     """
+    require_init()
     if not using_deepspeed:
         return (model, optimizer, training_data, lr_scheduler)
 
-    require_init()
     return deepspeed.initialize(
         args=args,
         model=model,
@@ -160,10 +160,10 @@ def check_batch_size(batch_size):
 
 def average_all(tensor):
     """Return the average of `tensor` over all workers."""
+    require_init()
     if not using_deepspeed:
         return tensor
 
-    require_init()
     require_torch_distributed_init()
     # We copy because modification happens in-place
     averaged = tensor.detach().clone()

--- a/dalle_pytorch/vae.py
+++ b/dalle_pytorch/vae.py
@@ -51,7 +51,7 @@ def unmap_pixels(x, eps = 0.1):
     return torch.clamp((x - eps) / (1 - 2 * eps), 0, 1)
 
 def download(url, filename = None, root = CACHE_PATH):
-    if deepspeed_utils.is_local_root_worker():
+    if deepspeed_utils.using_deepspeed and deepspeed_utils.is_local_root_worker():
         os.makedirs(root, exist_ok = True)
     filename = default(filename, os.path.basename(url))
 
@@ -61,7 +61,11 @@ def download(url, filename = None, root = CACHE_PATH):
     if os.path.exists(download_target) and not os.path.isfile(download_target):
         raise RuntimeError(f"{download_target} exists and is not a regular file")
 
-    if not deepspeed_utils.is_local_root_worker() and not os.path.isfile(download_target):
+    if (
+            deepspeed_utils.using_deepspeed
+            and not deepspeed_utils.is_local_root_worker()
+            and not os.path.isfile(download_target)
+    ):
         # If the file doesn't exist yet, wait until it's downloaded by the root worker.
         deepspeed_utils.local_barrier()
 


### PR DESCRIPTION
Hey, sorry for the back-and-forth. Your changes made much more sense as my idea with requiring DeepSpeed initialization early was to prevent DeepSpeed not being used because it was not initialized (as the optionality of it makes sure code should always work without it). And library code does not depend on its initialization.

To give an example, if a user writes their own script with optional DeepSpeed support but forgets the initialization call, they will wonder why the code does not get distributed at all. Now we again prevent that from happening, at least, as other required calls from `deepspeed_utils` should catch those cases.

I instead improved the error messages to be less confusing so users don't assume DeepSpeed is a necessity for the initialization function call.