### PR TITLE
Add .bmp image file support

### DIFF
--- a/train_dalle.py
+++ b/train_dalle.py
@@ -173,7 +173,8 @@ class TextImageDataset(Dataset):
         image_files = [
             *path.glob('**/*.png'),
             *path.glob('**/*.jpg'),
-            *path.glob('**/*.jpeg')
+            *path.glob('**/*.jpeg'),
+            *path.glob('**/*.bmp')
         ]
 
         text_files = {t.stem: t for t in text_files}


### PR DESCRIPTION
Adds .bmp image support. Useful for training with uncompressed data, such as spectrograms.