### PR TITLE
Sparse Attention on CUDA 11

### DIFF
--- a/install_deepspeed.sh
+++ b/install_deepspeed.sh
@@ -1,3 +1,3 @@
 sudo apt-get -y install llvm-9-dev cmake
-git clone https://github.com/microsoft/DeepSpeed.git /tmp/Deepspeed
+git clone https://github.com/afiaka87/DeepSpeed.git /tmp/Deepspeed
 cd /tmp/Deepspeed && DS_BUILD_SPARSE_ATTN=1 ./install.sh -s


### PR DESCRIPTION
The main deepspeed repo currently has a branch with the fix for sparse attention on CUDA 11. I've forked that branch to my account.  I've verified this works on both an A100 and an RTX3090 (thanks to @robvanvolt)