### PR TITLE
Fix various DeepSpeed issues

### DIFF
--- a/dalle_pytorch/dalle_pytorch.py
+++ b/dalle_pytorch/dalle_pytorch.py
@@ -159,7 +159,7 @@ class DiscreteVAE(nn.Module):
     @torch.no_grad()
     @eval_decorator
     def get_codebook_indices(self, images):
-        logits = self.forward(images, return_logits = True)
+        logits = self(images, return_logits = True)
         codebook_indices = logits.argmax(dim = 1).flatten(1)
         return codebook_indices
 

--- a/dalle_pytorch/distributed_backends/deepspeed_backend.py
+++ b/dalle_pytorch/distributed_backends/deepspeed_backend.py
@@ -34,6 +34,8 @@ class DeepSpeedBackend(DistributedBackend):
 
     def _initialize(self):
         self.backend_module.init_distributed()
+        if torch.cuda.is_available():
+            torch.cuda.set_device(self._get_local_rank())
 
     @staticmethod
     def _require_torch_distributed_init():

--- a/dalle_pytorch/vae.py
+++ b/dalle_pytorch/vae.py
@@ -151,6 +151,21 @@ class VQGanVAE1024(nn.Module):
         self.image_size = 256
         self.num_tokens = 1024
 
+        self._register_external_parameters()
+
+    def _register_external_parameters(self):
+        """Register external parameters for DeepSpeed partitioning."""
+        if (
+                not distributed_utils.is_distributed
+                or not distributed_utils.using_backend(
+                    distributed_utils.DeepSpeedBackend)
+        ):
+            return
+
+        deepspeed = distributed_utils.backend.backend_module
+        deepspeed.zero.register_external_parameters(
+            self, self.model.quantize.embedding.weight)
+
     @torch.no_grad()
     def get_codebook_indices(self, img):
         b = img.shape[0]

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -322,7 +322,7 @@ deepspeed_config = {
 avoid_model_calls = using_deepspeed and args.fp16
 
 # training
-torch.cuda.empty_cache() # Avoid allocation error due to potential bug in deepspeed. See https://github.com/lucidrains/DALLE-pytorch/issues/161
+
 for epoch in range(EPOCHS):
     for i, (text, images) in enumerate(distr_dl):
         if args.fp16:

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -259,9 +259,10 @@ dl = DataLoader(ds, batch_size = BATCH_SIZE, shuffle = not data_sampler,
 # initialize DALL-E
 
 dalle = DALLE(vae = vae, **dalle_params)
-if args.fp16:
-    dalle = dalle.half()
-dalle = dalle.cuda()
+if not using_deepspeed:
+    if args.fp16:
+        dalle = dalle.half()
+    dalle = dalle.cuda()
 
 
 if RESUME:

--- a/train_vae.py
+++ b/train_vae.py
@@ -101,6 +101,8 @@ vae = DiscreteVAE(
     smooth_l1_loss = SMOOTH_L1_LOSS,
     kl_div_loss_weight = KL_LOSS_WEIGHT
 )
+if not using_deepspeed:
+    vae = vae.cuda()
 
 
 assert len(ds) > 0, 'folder does not contain any images'


### PR DESCRIPTION
Revert #204 which disabled GPU usage for VAE training.
Fix #161, fix #185.

- We now let DeepSpeed handle converting the model to FP16 and moving it to GPU(s).
- Remove hacks regarding DeepSpeed and GPU memory usage.
- Register external parameters (could probably be detected automatically with DeepSpeed >= 0.3.15 but we (1) support compatibility for older versions and (2) don't care in case they can _not_ automatically be detected).