### PR TITLE
DeepSpeed sanity checks and LR scheduler fix

### DIFF
--- a/train_dalle.py
+++ b/train_dalle.py
@@ -378,7 +378,9 @@ for epoch in range(EPOCHS):
 
             wandb.log(log)
 
-    if LR_DECAY:
+    if LR_DECAY and not using_deepspeed:
+        # Scheduler is automatically progressed after the step when
+        # using DeepSpeed.
         distr_scheduler.step(loss)
 
     if distr_backend.is_root_worker():

--- a/train_vae.py
+++ b/train_vae.py
@@ -216,7 +216,10 @@ for epoch in range(EPOCHS):
 
             # lr decay
 
-            distr_sched.step()
+            if not using_deepspeed:
+                # Scheduler is automatically progressed after the step
+                # when using DeepSpeed.
+                distr_sched.step()
 
         # Collective loss, averaged
         avg_loss = distr_backend.average_all(loss)


### PR DESCRIPTION
Check command line arguments and DeepSpeed config for previously silently resolved conflicting specifications, warn about the precedence and handle conflicts predictably.

Also DeepSpeed progresses the LR scheduler already, we thus avoid doing it manually when using DeepSpeed.