### PR TITLE
Handle distributed backend args better

### DIFF
--- a/dalle_pytorch/distributed_backends/horovod_backend.py
+++ b/dalle_pytorch/distributed_backends/horovod_backend.py
@@ -10,20 +10,6 @@ class HorovodBackend(DistributedBackend):
     BACKEND_NAME = 'Horovod'
 
     def wrap_arg_parser(self, parser):
-        if not self.has_backend():
-            parser.add_argument(
-                '--horovod',
-                type=lambda _: False,
-                help=(
-                    "whether to use Horovod (ignored since it's not available)"
-                ),
-            )
-        else:
-            parser.add_argument(
-                '--horovod',
-                action='store_true',
-                help='whether to use Horovod',
-            )
         return parser
 
     def check_batch_size(self, batch_size):

--- a/dalle_pytorch/distributed_utils.py
+++ b/dalle_pytorch/distributed_utils.py
@@ -62,6 +62,12 @@ def set_backend_from_args(args):
     for distr_backend in BACKENDS:
         if distr_backend.BACKEND_NAME.lower() == backend_name:
             backend = distr_backend
+            if not backend.has_backend():
+                raise ModuleNotFoundError(
+                    f'{backend.BACKEND_NAME} backend selected but '
+                    'module not available'
+                )
+
             print(f'Using {backend.BACKEND_NAME} for distributed execution')
             return backend
 


### PR DESCRIPTION
- Remove redundant Horovod arguments.
- Raise an error when a selected backend is not available.

Fix #212