### PR TITLE
WIP: Fix DeepSpeed checkpointing issues

### DIFF
--- a/dalle_pytorch/distributed_utils.py
+++ b/dalle_pytorch/distributed_utils.py
@@ -11,7 +11,7 @@ You can check whether a backend is in use with the `using_backend`
 function.
 """
 
-from torch import Module
+from torch.nn import Module
 
 from dalle_pytorch.distributed_backends import \
     DeepSpeedBackend, \

--- a/dalle_pytorch/vae.py
+++ b/dalle_pytorch/vae.py
@@ -14,6 +14,7 @@ from math import sqrt
 from omegaconf import OmegaConf
 from taming.models.vqgan import VQModel
 
+import dall_e  # So DeepSpeed knows about the used classes.
 import torch
 from torch import nn
 import torch.nn.functional as F

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -124,7 +124,7 @@ def load_checkpoint(model, weights, path):
                         list(dalle.parameters(recurse=False)),
                         modifier_rank=distr_backend.ROOT_RANK,
                 ):
-                    if distr_backend.is_root_rank():
+                    if distr_backend.is_root_worker():
                         module._load_from_state_dict(weights, prefix)
 
                 for name, child in module._modules.items():

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -112,14 +112,8 @@ def cp_path_to_dir(cp_path, tag):
     return cp_dir
 
 
-def load_checkpoint(model, state_dict, path):
+def load_checkpoint(model, state_dict):
     if using_deepspeed:
-        cp_dir = cp_path_to_dir(path, 'ds')
-
-        if cp_dir.is_dir():
-            # We can load a DeepSpeed checkpoint instead.
-            return
-
         missing_keys = []
         unexpected_keys = []
         error_msgs = []
@@ -280,7 +274,12 @@ if not using_deepspeed:
     dalle = dalle.cuda()
 
 if RESUME:
-    load_checkpoint(dalle, weights, DALLE_PATH)
+    cp_dir = cp_path_to_dir(DALLE_PATH, 'ds')
+    # If this directory exists, we can load a DeepSpeed
+    # checkpoint instead.
+    if not using_deepspeed or not cp_dir.is_dir():
+        load_checkpoint(dalle, weights)
+
 
 # optimizer
 

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -179,11 +179,6 @@ else:
         loss_img_weight=LOSS_IMG_WEIGHT
     )
 
-# configure OpenAI VAE for float16s
-
-if isinstance(vae, OpenAIDiscreteVAE) and args.fp16:
-    vae.enc.blocks.output.conv.use_float16 = True
-
 
 # helpers
 

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -151,9 +151,9 @@ def load_checkpoint(model, state_dict, path):
                 if child is not None:
                     load_partitioned(child, prefix + name + '.')
 
-        load_partitioned(dalle)
+        load_partitioned(model)
     else:
-        dalle.load_state_dict(state_dict)
+        model.load_state_dict(state_dict)
 
 
 if using_deepspeed:

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -133,7 +133,7 @@ def load_checkpoint(model, state_dict, path):
                 local_metadata = metadata.get(prefix[:-1], {})
 
             with distr_backend.backend_module.zero.GatheredParameters(
-                    list(dalle.parameters(recurse=False)),
+                    list(module.parameters(recurse=False)),
                     modifier_rank=distr_backend.ROOT_RANK,
             ):
                 if distr_backend.is_root_worker():


### PR DESCRIPTION
### Still very broken; please take a look later.

Does not yet support loading a VAE DeepSpeed checkpoint for the DALL-E model.

- Add DeepSpeed checkpointing.
- Add compatibility to load non-DeepSpeed checkpoints for resuming training.
- When DeepSpeed is used, we only save DeepSpeed checkpoints. These can be converted to standard checkpoints using scripts in the DeepSpeed repo (look for "consolidating checkpoints").
- A nice side effect is that we are now also able to initialize models that don't fit into memory.

Need testing to see whether this allows loading the broken ZeRO stage 3 checkpoint in #211. @afiaka87 pretty please? :sparkles::eye::lips::eye: