### PR TITLE
Created a Dockerfile 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Before we replicate this, we can settle for <a href="https://github.com/lucidrai
 $ pip install dalle-pytorch
 ```
 
+## Build a docker Container
+The Docker container will make sure that the version of pytorch and cuda are correct. It has only been tested for nvidia cuda gpus. <a href="https://docs.docker.com/get-docker/">Docker</a> and <a href='#'>Docker Container Runtime</a> installed.
+
+To build:
+```bash
+docker build -t dalle docker
+```
+To run in an interactive shell:
+```bash
+docker run --gpus all --mount repo_or_dataset:/dalle/any_subdirectory_that_you_will_access_it dalle:latest /bin/bash
+```
+
 ## Usage
 
 Train VAE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,9 @@
+
+ARG IMG_TAG=1.6.0-cuda10.1-cudnn7-runtime
+ARG IMG_REPO=pytorch
+
+FROM pytorch/$IMG_REPO:$IMG_TAG
+
+RUN pip install dalle-pytorch
+
+WORKDIR dalle

--- a/docker/gpu.Dockerfile
+++ b/docker/gpu.Dockerfile
@@ -1,0 +1,5 @@
+FROM pytorch/pytorch:1.6.0-cuda10.1-cudnn7-runtime
+
+RUN pip install dalle-pytorch
+
+WORKDIR dalle

--- a/docker/gpu.Dockerfile
+++ b/docker/gpu.Dockerfile
@@ -1,5 +1,0 @@
-FROM pytorch/pytorch:1.6.0-cuda10.1-cudnn7-runtime
-
-RUN pip install dalle-pytorch
-
-WORKDIR dalle


### PR DESCRIPTION
This way it can be easier to make sure that the cuda and PyTorch versions can run properly. 
It will need to be run with interactive veiw. 

To build it run
`docker build -t dalle docker/`

To run it use 
`docker run --gpus all --mount repo_or_dataset:/dalle/any_subdirectory_that_you_will_access_it dalle:latest /bin/bash`

It will work for mounting a clone of the repository to have access to the train.py scripts. 