### PR TITLE
use data_sampler.set_epoch to avoid having the same order in each epoch

### DIFF
--- a/train_dalle.py
+++ b/train_dalle.py
@@ -280,6 +280,8 @@ avoid_model_calls = using_deepspeed and args.fp16
 # training
 
 for epoch in range(EPOCHS):
+    if data_sampler:
+        data_sampler.set_epoch(epoch)
     for i, (text, images) in enumerate(distr_dl):
         if args.fp16:
             images = images.half()


### PR DESCRIPTION
data_sampler `set_epoch` method should be called at each epoch so that the order is different.
See here: <https://pytorch.org/docs/stable/data.html>


> In distributed mode, calling the set_epoch() method at the beginning of each epoch before 
> creating the DataLoader iterator is necessary to make shuffling work properly across multiple epochs. 
> Otherwise, the same ordering will be always used.
