### PR TITLE
Easily enable apex O1 amp from train_dalle.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,16 +438,17 @@ for each one. See the [DeepSpeed configuration
 docs](https://www.deepspeed.ai/docs/config-json/) for more
 information.
 
-##### 16 bit Precision
+#### DeepSpeed - 16 bit Precision
 As of DeepSpeed version 0.3.16, ZeRO optimizations can be used with
 single-precision floating point numbers. If you are using an older
 version, you'll have to pass the `--fp16` flag to be able to enable
 ZeRO optimizations.
 
 
-##### Apex Automatic Mixed Precision.
-In order to run with Apex AMP (through DeepSpeed), you will need to install DeepSpeed using either the Dockerfile or the bash script. Then you will need to install apex from source:
-
+#### DeepSpeed - Apex Automatic Mixed Precision.
+Automatic mixed precision is a stable alternative to fp16 which still provides a decent speedup.
+In order to run with Apex AMP (through DeepSpeed), you will need to install DeepSpeed using either the Dockerfile or the bash script.
+Then you will need to install apex from source:
 ```sh
 git clone https://github.com/NVIDIA/apex
 cd apex
@@ -455,13 +456,12 @@ pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp
 cd ..
 ```
 
-Run `train_dalle.py` with `deepspeed` as done here:
+Now, run `train_dalle.py` with `deepspeed` instead of `python` as done here:
 ```sh
-deepspeed train_dalle.py --taming \
-    --image_text_folder Datasets \
-    --depth 8 \
-    --heads 8 \
-    --distr_backend deepspeed \
+deepspeed train_dalle.py \
+    --taming \
+    --image_text_folder 'DatasetsDir' \
+    --distr_backend 'deepspeed' \
     --amp
 ```
 

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ for each one. See the [DeepSpeed configuration
 docs](https://www.deepspeed.ai/docs/config-json/) for more
 information.
 
-#### DeepSpeed - 16 bit Precision
+#### DeepSpeed - 32 and 16 bit Precision
 As of DeepSpeed version 0.3.16, ZeRO optimizations can be used with
 single-precision floating point numbers. If you are using an older
 version, you'll have to pass the `--fp16` flag to be able to enable

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ In order to run with Apex AMP (through DeepSpeed), you will need to install Deep
 Then you will need to install apex from source. 
 This may take awhile and you may see some compilation warnings which can be ignored. 
 ```sh
-sh install_deepspeed.sh
+sh install_apex.sh
 ```
 
 Now, run `train_dalle.py` with `deepspeed` instead of `python` as done here:

--- a/README.md
+++ b/README.md
@@ -448,12 +448,11 @@ ZeRO optimizations.
 #### DeepSpeed - Apex Automatic Mixed Precision.
 Automatic mixed precision is a stable alternative to fp16 which still provides a decent speedup.
 In order to run with Apex AMP (through DeepSpeed), you will need to install DeepSpeed using either the Dockerfile or the bash script.
-Then you will need to install apex from source:
+
+Then you will need to install apex from source. 
+This may take awhile and you may see some compilation warnings which can be ignored. 
 ```sh
-git clone https://github.com/NVIDIA/apex
-cd apex
-pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
-cd ..
+sh install_deepspeed.sh
 ```
 
 Now, run `train_dalle.py` with `deepspeed` instead of `python` as done here:

--- a/README.md
+++ b/README.md
@@ -438,10 +438,32 @@ for each one. See the [DeepSpeed configuration
 docs](https://www.deepspeed.ai/docs/config-json/) for more
 information.
 
+##### 16 bit Precision
 As of DeepSpeed version 0.3.16, ZeRO optimizations can be used with
 single-precision floating point numbers. If you are using an older
 version, you'll have to pass the `--fp16` flag to be able to enable
 ZeRO optimizations.
+
+
+##### Apex Automatic Mixed Precision.
+In order to run with Apex AMP (through DeepSpeed), you will need to install DeepSpeed using either the Dockerfile or the bash script. Then you will need to install apex from source:
+
+```sh
+git clone https://github.com/NVIDIA/apex
+cd apex
+pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
+cd ..
+```
+
+Run `train_dalle.py` with `deepspeed` as done here:
+```sh
+deepspeed train_dalle.py --taming \
+    --image_text_folder Datasets \
+    --depth 8 \
+    --heads 8 \
+    --distr_backend deepspeed \
+    --amp
+```
 
 #### Horovod
 

--- a/install_apex.sh
+++ b/install_apex.sh
@@ -1,0 +1,2 @@
+git clone https://github.com/NVIDIA/apex.git /tmp/apex
+cd /tmp/apex && pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -331,7 +331,7 @@ deepspeed_config = {
     },
     'amp': {
         'enabled': args.amp,
-	'opt_level': 'O1',
+        'opt_level': 'O1',
     },
 }
 

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -50,6 +50,13 @@ parser.add_argument('--dalle_output_file_name', type=str, default = "dalle.pt",
 parser.add_argument('--fp16', action='store_true',
                     help='(experimental) - Enable DeepSpeed 16 bit precision. Reduces VRAM.')
 
+
+parser.add_argument(
+	'--amp',
+	action='store_true',
+	help='Apex "O1" automatic mixed precision. More stable than 16 bit precision. Can\'t be used in conjunction with deepspeed zero stages 1-3.'
+)
+
 parser.add_argument('--wandb_name', default='dalle_train_transformer',
                     help='Name W&B will use when saving results.\ne.g. `--wandb_name "coco2017-full-sparse"`')
 
@@ -321,6 +328,10 @@ deepspeed_config = {
     'gradient_clipping': GRAD_CLIP_NORM,
     'fp16': {
         'enabled': args.fp16,
+    },
+    'amp': {
+        'enabled': args.amp,
+	'opt_level': 'O1',
     },
 }
 


### PR DESCRIPTION
CogView sidestepped needing to "tame" 16 bit precision by just using "O2" (almost 16 bit) precision. 

I tried implementing O2 and I think it's rather possible but there are some casts from Long to Float which need to happen for it to work. 

The O1 case works very well as is however. In my case (RTX 2070) - I go from ~16 samples per second to ~40 samples per second. using fp16 instead I get around ~50 samples. So it's faster but not necessarily by much. I assume this benchmark changes drastically when the comms latency of a multi-node system needs to be considered and my intuition is that sending half as many bits across the wire can make something like optimizer offloading and allreduce more effective. 

tl;dr automatic mixed precision is slower than fp16, but you'll be able to see generations during training and won't have to deal with potential divergence issues caused by training fp16.