### PR TITLE
add vqgan_model_path and vqgan_config_path parameters for custom vqgan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,14 @@ In contrast to OpenAI's VAE, it also has an extra layer of downsampling, so the 
 Update - <a href="https://github.com/lucidrains/DALLE-pytorch/discussions/131">it works!</a>
 
 ```python
-from dalle_pytorch import VQGanVAE1024
+from dalle_pytorch import VQGanVAE
 
-vae = VQGanVAE1024()
+vae = VQGanVAE()
 
 # the rest is the same as the above example
 ```
+
+The default VQGan is the codebook size 1024 one trained on imagenet. If you wish to use a different one, you can use the `vqgan_model_path` and `vqgan_config_path` to pass the .ckpt file and the .yaml file. These options can be used both in train-dalle script or as argument of VQGanVAE class. Other pretrained VQGAN can be found in [taming transformers readme](https://github.com/CompVis/taming-transformers#overview-of-pretrained-models). If you want to train a custom one you can [follow this guide](https://github.com/CompVis/taming-transformers/pull/54)
 
 ## Ranking the generations
 

--- a/dalle_pytorch/__init__.py
+++ b/dalle_pytorch/__init__.py
@@ -1,2 +1,2 @@
 from dalle_pytorch.dalle_pytorch import DALLE, CLIP, DiscreteVAE
-from dalle_pytorch.vae import OpenAIDiscreteVAE, VQGanVAE1024
+from dalle_pytorch.vae import OpenAIDiscreteVAE, VQGanVAE

--- a/dalle_pytorch/dalle_pytorch.py
+++ b/dalle_pytorch/dalle_pytorch.py
@@ -7,8 +7,7 @@ from axial_positional_embedding import AxialPositionalEmbedding
 from einops import rearrange
 
 from dalle_pytorch import distributed_utils
-from dalle_pytorch.vae import OpenAIDiscreteVAE
-from dalle_pytorch.vae import VQGanVAE1024
+from dalle_pytorch.vae import OpenAIDiscreteVAE, VQGanVAE
 from dalle_pytorch.transformer import Transformer, DivideMax
 
 # helpers
@@ -325,7 +324,7 @@ class DALLE(nn.Module):
         stable = False
     ):
         super().__init__()
-        assert isinstance(vae, (DiscreteVAE, OpenAIDiscreteVAE, VQGanVAE1024)), 'vae must be an instance of DiscreteVAE'
+        assert isinstance(vae, (DiscreteVAE, OpenAIDiscreteVAE, VQGanVAE)), 'vae must be an instance of DiscreteVAE'
 
         image_size = vae.image_size
         num_image_tokens = vae.num_tokens

--- a/generate.py
+++ b/generate.py
@@ -15,7 +15,7 @@ from torchvision.utils import make_grid, save_image
 
 # dalle related classes and utils
 
-from dalle_pytorch import DiscreteVAE, OpenAIDiscreteVAE, VQGanVAE1024, DALLE
+from dalle_pytorch import DiscreteVAE, OpenAIDiscreteVAE, VQGanVAE, DALLE
 from dalle_pytorch.tokenizer import tokenizer, HugTokenizer, YttmTokenizer, ChineseTokenizer
 
 # argument parsing
@@ -24,6 +24,12 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument('--dalle_path', type = str, required = True,
                     help='path to your trained DALL-E')
+
+parser.add_argument('--vqgan_model_path', type=str, default = None,
+                   help='path to your trained VQGAN weights. This should be a .ckpt file. (only valid when taming option is enabled)')
+
+parser.add_argument('--vqgan_config_path', type=str, default = None,
+                   help='path to your trained VQGAN config. This should be a .yaml file.  (only valid when taming option is enabled)')
 
 parser.add_argument('--text', type = str, required = True,
                     help='your text prompt')
@@ -80,7 +86,7 @@ if vae_params is not None:
 elif not args.taming:
     vae = OpenAIDiscreteVAE()
 else:
-    vae = VQGanVAE1024()
+    vae = VQGanVAE(args.vqgan_model_path, args.vqgan_config_path)
 
 
 dalle = DALLE(vae = vae, **dalle_params).cuda()

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -12,7 +12,7 @@ from torch.optim import Adam
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torch.utils.data import DataLoader
 
-from dalle_pytorch import OpenAIDiscreteVAE, VQGanVAE1024, DiscreteVAE, DALLE
+from dalle_pytorch import OpenAIDiscreteVAE, VQGanVAE, DiscreteVAE, DALLE
 from dalle_pytorch import distributed_utils
 from dalle_pytorch.loader import TextImageDataset
 from dalle_pytorch.tokenizer import tokenizer, HugTokenizer, ChineseTokenizer, YttmTokenizer
@@ -28,6 +28,12 @@ group.add_argument('--vae_path', type=str,
 
 group.add_argument('--dalle_path', type=str,
                    help='path to your partially trained DALL-E')
+
+parser.add_argument('--vqgan_model_path', type=str, default = None,
+                   help='path to your trained VQGAN weights. This should be a .ckpt file. (only valid when taming option is enabled)')
+
+parser.add_argument('--vqgan_config_path', type=str, default = None,
+                   help='path to your trained VQGAN config. This should be a .yaml file. (only valid when taming option is enabled)')
 
 parser.add_argument('--image_text_folder', type=str, required=True,
                     help='path to your folder of images and text for learning the DALL-E')
@@ -132,6 +138,8 @@ def cp_path_to_dir(cp_path, tag):
 DALLE_OUTPUT_FILE_NAME = args.dalle_output_file_name + ".pt"
 
 VAE_PATH = args.vae_path
+VQGAN_MODEL_PATH = args.vqgan_model_path
+VQGAN_CONFIG_PATH = args.vqgan_config_path
 DALLE_PATH = args.dalle_path
 RESUME = exists(DALLE_PATH)
 
@@ -190,8 +198,10 @@ if RESUME:
     if vae_params is not None:
         vae = DiscreteVAE(**vae_params)
     else:
-        vae_klass = OpenAIDiscreteVAE if not args.taming else VQGanVAE1024
-        vae = vae_klass()
+        if args.taming:
+            vae = VQGanVAE(VQGAN_MODEL_PATH, VQGAN_CONFIG_PATH)
+        else:
+            vae = OpenAIDiscreteVAE()
 
     dalle_params = dict(
         **dalle_params
@@ -218,8 +228,10 @@ else:
             print('using pretrained VAE for encoding images to tokens')
         vae_params = None
 
-        vae_klass = OpenAIDiscreteVAE if not args.taming else VQGanVAE1024
-        vae = vae_klass()
+        if args.taming:
+            vae = VQGanVAE(VQGAN_MODEL_PATH, VQGAN_CONFIG_PATH)
+        else:
+            vae = OpenAIDiscreteVAE()
 
     IMAGE_SIZE = vae.image_size
 


### PR DESCRIPTION
load the vqgan model from the provided path and config when not None

This is still a draft:
* I need to run it to check it works
* This feels kind of awkward with the vae_params support directly stored in dalle.pt: where should we go ?

Should we move to storing all kind of vae weights in dalle.pt ? or should we remove the vae weight support and always pass both the vae path and dalle path when resuming/generating ?

Would be glad to have your opinions on this @afiaka87 @robvanvolt @lucidrains 


I think this is a feature we need because several people tried to do training with custom VQGAN and got confused as to whether they used the old or new vqgan weights