### PR TITLE
Fix small bug in computing the f in vqgan

### DIFF
--- a/dalle_pytorch/vae.py
+++ b/dalle_pytorch/vae.py
@@ -153,7 +153,9 @@ class VQGanVAE(nn.Module):
 
         self.model = model
 
-        self.num_layers = int(log(config.model.params.ddconfig.attn_resolutions[0])/log(2))
+        # f as used in https://github.com/CompVis/taming-transformers#overview-of-pretrained-models
+        f = config.model.params.ddconfig.resolution / config.model.params.ddconfig.attn_resolutions[0]
+        self.num_layers = int(log(f)/log(2))
         self.image_size = 256
         self.num_tokens = config.model.params.n_embed
 


### PR DESCRIPTION
Used to compute the attention resolution in dalle.
This didn't affect any previous training because all vqgan until today had a f=16 and 256=16*16
But would have affected use of the new vqgan released today that has f=8