### PR TITLE
Generate text with DALLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ images = dalle.generate_images(
 images.shape # (4, 3, 256, 256)
 ```
 
+You may also want to generate text using DALL-E. For that call this function:
+```
+text_tokens, texts = dalle.generate_texts(text)
+```
+
 ## OpenAI's Pretrained VAE
 
 You can also skip the training of the VAE altogether, using the pretrained model released by OpenAI! The wrapper class should take care of downloading and caching the model for you auto-magically.
@@ -456,6 +461,14 @@ ex.
 ```python
 $ python generate.py --dalle_path ./dalle.pt --text 'a dog chewing a bone|a cat chasing mice|a frog eating a fly'
 ```
+
+Note that DALL-E is a full image+text language model. As a consequence you can also generate text using a dalle model.
+
+```python
+$ python generate.py --dalle_path ./dalle.pt --text 'a dog chewing a bone' --gentext
+```
+
+This will complete the provided text, save it in a caption.txt and generate the corresponding images.
 
 ### Docker
 

--- a/dalle_pytorch/dalle_pytorch.py
+++ b/dalle_pytorch/dalle_pytorch.py
@@ -410,7 +410,7 @@ class DALLE(nn.Module):
         total_len = text_seq_len + image_seq_len
 
         text = text[:, :text_seq_len] # make sure text is within bounds
-        out = text[:,0:1]
+        out = text
 
         if exists(img):
             image_size = vae.image_size
@@ -423,43 +423,33 @@ class DALLE(nn.Module):
             indices = indices[:, :num_img_tokens]
             out = torch.cat((out, indices), dim = -1)
 
-        for cur_len in range(0, 50):
+        for cur_len in range(out.shape[1], total_len):
             is_image = cur_len >= text_seq_len
 
             text, image = out[:, :text_seq_len], out[:, text_seq_len:]
 
-            logits = self(text, image, mask = None)[:, -1, :]
+            logits = self(text, image, mask = mask)[:, -1, :]
 
             filtered_logits = top_k(logits, thres = filter_thres)
             probs = F.softmax(filtered_logits / temperature, dim = -1)
             sample = torch.multinomial(probs, 1)
 
-            #sample -= (num_text_tokens if is_image else 0) # offset sampled token if it is an image token, since logit space is composed of text and then image tokens
- 
+            sample -= (num_text_tokens if is_image else 0) # offset sampled token if it is an image token, since logit space is composed of text and then image tokens
             out = torch.cat((out, sample), dim=-1)
 
-            #if out.shape[1] <= text_seq_len:
-            #    mask = F.pad(mask, (0, 1), value = True)
+            if out.shape[1] <= text_seq_len:
+                mask = F.pad(mask, (0, 1), value = True)
 
-        text_seq = out[:, :50]
-        print("NUMBER OF TEXT TOKENS: {}".format(num_text_tokens))
-        print("OTHER")
-        print(len(tokenizer.tokenizer.decoder.keys()))
-        print(list(tokenizer.tokenizer.decoder.keys()))
+        text_seq = out[:, :text_seq_len]
 
-        #img_seq = out[:, -image_seq_len:]
-        #images = vae.decode(img_seq)
-
-        print(text_seq)
-        padding_tokens = list(torch.arange(self.text_seq_len) + (self.num_text_tokens - self.text_seq_len))
-
-        texts = tokenizer.tokenizer.decode(text_seq[0], ignore_pad_tokens=padding_tokens)
+        img_seq = out[:, -image_seq_len:]
+        images = vae.decode(img_seq)
 
         if exists(clip):
             scores = clip(text_seq, images, return_loss = False)
             return images, scores
 
-        return texts
+        return images
 
     def forward(
         self,
@@ -468,17 +458,17 @@ class DALLE(nn.Module):
         mask = None,
         return_loss = False
     ):
-        #assert text.shape[-1] == self.text_seq_len, f'the length {text.shape[-1]} of the text tokens you passed in does not have the correct length ({self.text_seq_len})'
+        assert text.shape[-1] == self.text_seq_len, f'the length {text.shape[-1]} of the text tokens you passed in does not have the correct length ({self.text_seq_len})'
         device, total_seq_len = text.device, self.total_seq_len
 
         # make sure padding in text tokens get unique padding token id
 
-        #text_range = torch.arange(self.text_seq_len, device = device) + (self.num_text_tokens - self.text_seq_len)
-        #text = torch.where(text == 0, text_range, text)
+        text_range = torch.arange(self.text_seq_len, device = device) + (self.num_text_tokens - self.text_seq_len)
+        text = torch.where(text == 0, text_range, text)
 
         # add <bos>
 
-        #text = F.pad(text, (1, 0), value = 0)
+        text = F.pad(text, (1, 0), value = 0)
 
         tokens = self.text_emb(text)
         tokens += self.text_pos_emb(torch.arange(text.shape[1], device = device))
@@ -548,6 +538,7 @@ class DALLE(nn.Module):
         *,
         filter_thres = 0.5,
         temperature = 1.,
+        decoded=True
     ):
         vae, text_seq_len, image_seq_len, num_text_tokens = self.vae, self.text_seq_len, self.image_seq_len, self.num_text_tokens
         total_len = text_seq_len + image_seq_len
@@ -562,26 +553,26 @@ class DALLE(nn.Module):
 
             seq_len = tokens.shape[1]
 
-            out = self.transformer(tokens)
+            output_transf = self.transformer(tokens)
 
             if self.stable:
-                out = self.norm_by_max(out)
+                output_transf = self.norm_by_max(output_transf)
 
-            logits = self.to_logits(out)
+            logits = self.to_logits(output_transf)
 
             # mask logits to make sure text predicts text (except last token), and image predicts image
 
             logits_mask = self.logits_mask[:, :seq_len]
             max_neg_value = -torch.finfo(logits.dtype).max
-            logits.masked_fill_(logits_mask, max_neg_value)[:, -1, :]
+            logits.masked_fill_(logits_mask, max_neg_value)
+            logits = logits[:, -1, :]
 
             filtered_logits = top_k(logits, thres = filter_thres)
             probs = F.softmax(filtered_logits / temperature, dim = -1)
             sample = torch.multinomial(probs, 1)
  
             text = torch.cat((text, sample), dim=-1)
-
-        
+    
         padding_tokens = list(torch.arange(self.text_seq_len, device = device) + (self.num_text_tokens - self.text_seq_len))
-        texts = tokenizer.tokenizer.decode(text[0], ignore_pad_tokens=padding_tokens)
-        return texts
+        texts_decoded = tokenizer.tokenizer.decode(text[0], ignore_pad_tokens=padding_tokens)
+        return text, texts_decoded

--- a/dalle_pytorch/dalle_pytorch.py
+++ b/dalle_pytorch/dalle_pytorch.py
@@ -394,6 +394,54 @@ class DALLE(nn.Module):
         self.register_buffer('logits_mask', logits_mask, persistent=False)
         self.loss_img_weight = loss_img_weight
 
+
+    @torch.no_grad()
+    @eval_decorator
+    def generate_texts(
+        self,
+        text=None,
+        *,
+        filter_thres = 0.5,
+        temperature = 1.
+    ):
+        text_seq_len = self.text_seq_len
+        if text is None or text == "":
+            text_tokens = torch.tensor([[0]]).cuda()
+        else:
+            text_tokens = torch.tensor(tokenizer.tokenizer.encode(text)).cuda().unsqueeze(0)
+   
+        for _ in range(text_tokens.shape[1], text_seq_len):
+            device = text_tokens.device
+
+            tokens = self.text_emb(text_tokens)
+            tokens += self.text_pos_emb(torch.arange(text_tokens.shape[1], device = device))
+
+            seq_len = tokens.shape[1]
+
+            output_transf = self.transformer(tokens)
+
+            if self.stable:
+                output_transf = self.norm_by_max(output_transf)
+
+            logits = self.to_logits(output_transf)
+
+            # mask logits to make sure text predicts text (except last token), and image predicts image
+
+            logits_mask = self.logits_mask[:, :seq_len]
+            max_neg_value = -torch.finfo(logits.dtype).max
+            logits.masked_fill_(logits_mask, max_neg_value)
+            logits = logits[:, -1, :]
+
+            filtered_logits = top_k(logits, thres = filter_thres)
+            probs = F.softmax(filtered_logits / temperature, dim = -1)
+            sample = torch.multinomial(probs, 1)
+ 
+            text_tokens = torch.cat((text_tokens, sample), dim=-1)
+    
+        padding_tokens = set(np.arange(self.text_seq_len) + (self.num_text_tokens - self.text_seq_len))
+        texts = [tokenizer.tokenizer.decode(text_token, pad_tokens=padding_tokens) for text_token in text_tokens]
+        return text_tokens, texts
+
     @torch.no_grad()
     @eval_decorator
     def generate_images(
@@ -531,51 +579,3 @@ class DALLE(nn.Module):
         return loss
     
     
-    
-    @torch.no_grad()
-    @eval_decorator
-    def generate_text(
-        self,
-        text=None,
-        *,
-        filter_thres = 0.5,
-        temperature = 1.,
-        decoded=True
-    ):
-        vae, text_seq_len, image_seq_len, num_text_tokens = self.vae, self.text_seq_len, self.image_seq_len, self.num_text_tokens
-        total_len = text_seq_len + image_seq_len
-        
-        if text is None:
-            text = torch.tensor([[0]]).cuda()
-
-        for cur_len in range(text.shape[1], text_seq_len):
-            device, total_seq_len = text.device, self.total_seq_len
-
-            tokens = self.text_emb(text)
-            tokens += self.text_pos_emb(torch.arange(text.shape[1], device = device))
-
-            seq_len = tokens.shape[1]
-
-            output_transf = self.transformer(tokens)
-
-            if self.stable:
-                output_transf = self.norm_by_max(output_transf)
-
-            logits = self.to_logits(output_transf)
-
-            # mask logits to make sure text predicts text (except last token), and image predicts image
-
-            logits_mask = self.logits_mask[:, :seq_len]
-            max_neg_value = -torch.finfo(logits.dtype).max
-            logits.masked_fill_(logits_mask, max_neg_value)
-            logits = logits[:, -1, :]
-
-            filtered_logits = top_k(logits, thres = filter_thres)
-            probs = F.softmax(filtered_logits / temperature, dim = -1)
-            sample = torch.multinomial(probs, 1)
- 
-            text = torch.cat((text, sample), dim=-1)
-    
-        padding_tokens = set(np.arange(self.text_seq_len) + (self.num_text_tokens - self.text_seq_len))
-        texts_decoded = tokenizer.tokenizer.decode(text[0], pad_tokens=padding_tokens)
-        return text, texts_decoded

--- a/dalle_pytorch/tokenizer.py
+++ b/dalle_pytorch/tokenizer.py
@@ -130,7 +130,7 @@ class SimpleTokenizer(object):
 
         if remove_start_end:
             tokens = [token for token in tokens if token not in (49406, 40407, 0)]
-        text = ''.join([self.decoder[token] for token in tokens])
+        text = ''.join([self.decoder[token] for token in tokens if token in self.decoder])
         text = bytearray([self.byte_decoder[c] for c in text]).decode('utf-8', errors="replace").replace('</w>', ' ')
         return text
 

--- a/dalle_pytorch/tokenizer.py
+++ b/dalle_pytorch/tokenizer.py
@@ -164,11 +164,11 @@ class HugTokenizer:
         self.tokenizer = tokenizer
         self.vocab_size = tokenizer.get_vocab_size()
 
-    def decode(self, tokens):
+    def decode(self, tokens, ignore_pad_tokens = []):
         if torch.is_tensor(tokens):
             tokens = tokens.tolist()
-
-        tokens = [token for token in tokens if token not in (0,)]
+        ignore_ids = [0] + pad_tokens
+        tokens = [token for token in tokens if token not in ignore_ids]
         return self.tokenizer.decode(tokens, skip_special_tokens = True)
 
     def encode(self, text):
@@ -199,11 +199,12 @@ class ChineseTokenizer:
         self.tokenizer = tokenizer
         self.vocab_size = tokenizer.vocab_size
 
-    def decode(self, tokens):
+    def decode(self, tokens, pad_tokens = []):
         if torch.is_tensor(tokens):
             tokens = tokens.tolist()
-
-        tokens = [token for token in tokens if token not in (0,)]
+            
+        ignore_ids = [0] + pad_tokens
+        tokens = [token for token in tokens if token not in ignore_ids]
         return self.tokenizer.decode(tokens)
 
     def encode(self, text):
@@ -237,11 +238,11 @@ class YttmTokenizer:
         self.tokenizer = tokenizer
         self.vocab_size = tokenizer.vocab_size()
 
-    def decode(self, tokens):
+    def decode(self, tokens, pad_tokens = []):
         if torch.is_tensor(tokens):
             tokens = tokens.tolist()
 
-        return self.tokenizer.decode(tokens, ignore_ids = [0])
+        return self.tokenizer.decode(tokens, ignore_ids = [0] + pad_tokens)
 
     def encode(self, texts):
         encoded = self.tokenizer.encode(texts, output_type = yttm.OutputType.ID)

--- a/dalle_pytorch/tokenizer.py
+++ b/dalle_pytorch/tokenizer.py
@@ -124,13 +124,13 @@ class SimpleTokenizer(object):
             bpe_tokens.extend(self.encoder[bpe_token] for bpe_token in self.bpe(token).split(' '))
         return bpe_tokens
 
-    def decode(self, tokens, remove_start_end = True, ignore_pad_tokens = []):
+    def decode(self, tokens, remove_start_end = True, pad_tokens = {}):
         if torch.is_tensor(tokens):
             tokens = tokens.tolist()
 
         if remove_start_end:
             tokens = [token for token in tokens if token not in (49406, 40407, 0)]
-        text = ''.join([self.decoder[token] for token in tokens if token not in ignore_pad_tokens])
+        text = ''.join([self.decoder[token] for token in tokens if token not in pad_tokens])
         text = bytearray([self.byte_decoder[c] for c in text]).decode('utf-8', errors="replace").replace('</w>', ' ')
         return text
 
@@ -164,10 +164,10 @@ class HugTokenizer:
         self.tokenizer = tokenizer
         self.vocab_size = tokenizer.get_vocab_size()
 
-    def decode(self, tokens, ignore_pad_tokens = []):
+    def decode(self, tokens, pad_tokens = {}):
         if torch.is_tensor(tokens):
             tokens = tokens.tolist()
-        ignore_ids = [0] + pad_tokens
+        ignore_ids = pad_tokens.union({0})
         tokens = [token for token in tokens if token not in ignore_ids]
         return self.tokenizer.decode(tokens, skip_special_tokens = True)
 
@@ -199,11 +199,11 @@ class ChineseTokenizer:
         self.tokenizer = tokenizer
         self.vocab_size = tokenizer.vocab_size
 
-    def decode(self, tokens, pad_tokens = []):
+    def decode(self, tokens, pad_tokens = {}):
         if torch.is_tensor(tokens):
             tokens = tokens.tolist()
             
-        ignore_ids = [0] + pad_tokens
+        ignore_ids = pad_tokens.union({0})
         tokens = [token for token in tokens if token not in ignore_ids]
         return self.tokenizer.decode(tokens)
 
@@ -238,11 +238,11 @@ class YttmTokenizer:
         self.tokenizer = tokenizer
         self.vocab_size = tokenizer.vocab_size()
 
-    def decode(self, tokens, pad_tokens = []):
+    def decode(self, tokens, pad_tokens = {}):
         if torch.is_tensor(tokens):
             tokens = tokens.tolist()
 
-        return self.tokenizer.decode(tokens, ignore_ids = [0] + pad_tokens)
+        return self.tokenizer.decode(tokens, ignore_ids = pad_tokens.union({0}))
 
     def encode(self, texts):
         encoded = self.tokenizer.encode(texts, output_type = yttm.OutputType.ID)

--- a/dalle_pytorch/tokenizer.py
+++ b/dalle_pytorch/tokenizer.py
@@ -124,13 +124,13 @@ class SimpleTokenizer(object):
             bpe_tokens.extend(self.encoder[bpe_token] for bpe_token in self.bpe(token).split(' '))
         return bpe_tokens
 
-    def decode(self, tokens, remove_start_end = True):
+    def decode(self, tokens, remove_start_end = True, ignore_pad_tokens = []):
         if torch.is_tensor(tokens):
             tokens = tokens.tolist()
 
         if remove_start_end:
             tokens = [token for token in tokens if token not in (49406, 40407, 0)]
-        text = ''.join([self.decoder[token] for token in tokens if token in self.decoder])
+        text = ''.join([self.decoder[token] for token in tokens if token not in ignore_pad_tokens])
         text = bytearray([self.byte_decoder[c] for c in text]).decode('utf-8', errors="replace").replace('</w>', ' ')
         return text
 

--- a/generate.py
+++ b/generate.py
@@ -110,7 +110,9 @@ for text in tqdm(texts):
         output = dalle.generate_images(text_chunk, filter_thres = args.top_k)
         outputs.append(output)
 
-    outputs = torch.cat(outputs)
+    #outputs = torch.cat(outputs)
+    print(outputs)
+    break
 
     # save all images
 

--- a/generate.py
+++ b/generate.py
@@ -55,6 +55,8 @@ parser.add_argument('--chinese', dest='chinese', action = 'store_true')
 
 parser.add_argument('--taming', dest='taming', action='store_true')
 
+parser.add_argument('--gentxt', dest='gentxt', action='store_true')
+
 args = parser.parse_args()
 
 # helper fns
@@ -99,27 +101,33 @@ image_size = vae.image_size
 
 texts = args.text.split('|')
 
-for text in tqdm(texts):
-    text = tokenizer.tokenize([args.text], dalle.text_seq_len).cuda()
+if args.gentxt:
+    texts, gen_text_decoded = dalle.generate_text(filter_thres = args.top_k)
 
-    text = repeat(text, '() n -> b n', b = args.num_images)
+for j, text in tqdm(enumerate(texts)):
+    if args.gentxt:
+        text_tokens = text.unsqueeze(0)
+    else:
+        text_tokens = tokenizer.tokenize([text], dalle.text_seq_len).cuda()
+
+    text_tokens = repeat(text_tokens, '() n -> b n', b = args.num_images)
 
     outputs = []
 
-    for text_chunk in tqdm(text.split(args.batch_size), desc = f'generating images for - {text}'):
-        output = dalle.generate_text(filter_thres = args.top_k) # generate_images(text_chunk, filter_thres = args.top_k)
+    for text_chunk in tqdm(text_tokens.split(args.batch_size), desc = f'generating images for - {text}'):
+        output = dalle.generate_images(text_chunk, filter_thres = args.top_k)
         outputs.append(output)
 
-    #outputs = torch.cat(outputs)
-    print(outputs)
-    break
+    outputs = torch.cat(outputs)
 
     # save all images
-
-    outputs_dir = Path(args.outputs_dir) / args.text.replace(' ', '_')[:(100)]
+    file_name = gen_text_decoded if args.gentxt else text 
+    outputs_dir = Path(args.outputs_dir) / file_name.replace(' ', '_')[:(100)]
     outputs_dir.mkdir(parents = True, exist_ok = True)
 
     for i, image in tqdm(enumerate(outputs), desc = 'saving images'):
         save_image(image, outputs_dir / f'{i}.jpg', normalize=True)
+        with open(outputs_dir / 'caption.txt', 'w') as f:
+            f.write(file_name)
 
     print(f'created {args.num_images} images at "{str(outputs_dir)}"')

--- a/generate.py
+++ b/generate.py
@@ -107,7 +107,7 @@ for text in tqdm(texts):
     outputs = []
 
     for text_chunk in tqdm(text.split(args.batch_size), desc = f'generating images for - {text}'):
-        output = dalle.generate_images(text_chunk, filter_thres = args.top_k)
+        output = dalle.generate_text(filter_thres = args.top_k) # generate_images(text_chunk, filter_thres = args.top_k)
         outputs.append(output)
 
     #outputs = torch.cat(outputs)

--- a/generate.py
+++ b/generate.py
@@ -101,12 +101,10 @@ image_size = vae.image_size
 
 texts = args.text.split('|')
 
-if args.gentxt:
-    texts, gen_text_decoded = dalle.generate_text(filter_thres = args.top_k)
-
 for j, text in tqdm(enumerate(texts)):
     if args.gentxt:
-        text_tokens = text.unsqueeze(0)
+        text_tokens, gen_texts = dalle.generate_texts(text=text, filter_thres = args.top_k)
+        text = gen_texts[0]
     else:
         text_tokens = tokenizer.tokenize([text], dalle.text_seq_len).cuda()
 
@@ -121,7 +119,7 @@ for j, text in tqdm(enumerate(texts)):
     outputs = torch.cat(outputs)
 
     # save all images
-    file_name = gen_text_decoded if args.gentxt else text 
+    file_name = text 
     outputs_dir = Path(args.outputs_dir) / file_name.replace(' ', '_')[:(100)]
     outputs_dir.mkdir(parents = True, exist_ok = True)
 


### PR DESCRIPTION
Since DALLE trains a multimodal language model, the text part of the sequence can also be generated from scratch.
I added a new method to generate text in the DALLE class and also an argument in generate.py so that the generated image can be conditioned on a generated text instead of an input text.
To make this work I had to add an "ignore_tokens" argument to the decoder method of each argument otherwise the tokenizers raise an error when trying to decode padding tokens.