### PR TITLE
Fix for VQGAN after update of taming transformer dependency

### DIFF
--- a/dalle_pytorch/vae.py
+++ b/dalle_pytorch/vae.py
@@ -196,7 +196,7 @@ class VQGanVAE(nn.Module):
         _, _, [_, _, indices] = self.model.encode(img)
         if self.is_gumbel:
             return rearrange(indices, 'b h w -> b (h w)', b=b)
-        return rearrange(indices, '(b n) () -> b n', b = b)
+        return rearrange(indices, '(b n) -> b n', b = b)
 
     def decode(self, img_seq):
         b, n = img_seq.shape


### PR DESCRIPTION
in the v3 of their paper, taming transformers authors changed the implementation of the VectorQuantizer
see https://github.com/CompVis/taming-transformers/commit/04c8ad6c0fa4650e3d600faee793515c4aa2658c#diff-92ba76a137f5007f09ae7afd810f7bda5bb8f85d2089658122061ee458155c62R31
(VectorQuantizer2 is imported as Vector Quantizer)

As a consequence, the shape of the indices returned by self.model.encode changed slightly

This commit adapts for this change.