### PR TITLE
Quickfix WDS

### DIFF
--- a/train_dalle.py
+++ b/train_dalle.py
@@ -382,8 +382,8 @@ else:
         tokenizer=tokenizer,
         shuffle=is_shuffle,
     )
+    assert len(ds) > 0, 'dataset is empty'
 
-assert len(ds) > 0, 'dataset is empty'
 if distr_backend.is_root_worker():
     if not ENABLE_WEBDATASET:
         print(f'{len(ds)} image-text pairs found for training')


### PR DESCRIPTION
Deprecated length attribute got removed in the latest WebDataset version, so only check the length of the dataset if not using WDS.
Thanks to ARKseal for pointing out to that bug.