### PR TITLE
Fix rotary embeddings in sparse attention

### DIFF
--- a/dalle_pytorch/transformer.py
+++ b/dalle_pytorch/transformer.py
@@ -223,7 +223,7 @@ class Transformer(nn.Module):
             img_freqs = torch.cat((text_axial_freqs, img_freqs), dim = 0)
 
             pos_emb = torch.cat((text_freqs, img_freqs), dim = -1)
-            pos_emb = rearrange(pos_emb[:-1], 'n d -> () () n d')
+            pos_emb = rearrange(pos_emb, 'n d -> () n d')
 
         self.register_buffer('pos_emb', pos_emb)
 


### PR DESCRIPTION
Currently, rotary embeddings do not work with sparse attention. For example, this command fails:

```python
$ python train_dalle.py --image_text_folder dataset/00000.tar --wds jpg,txt --truncate_captions \
    --rotary_emb --depth 5 --attn_types axial_row,axial_col,axial_row,axial_row,conv_like

[...]
  File "/home/user/dalle/dalle-pytorch/dalle_pytorch/attention.py", line 35, in <lambda>                                 
    return tuple(map(lambda t: apply_rotary_emb(pos_emb, t), qkv))
  File "/home/user/anaconda3/envs/dalle/lib/python3.8/site-packages/rotary_embedding_torch/rotary_embedding_torch.py", line 45, in apply_rotary_emb
    t = (t * freqs.cos()) + (rotate_half(t) * freqs.sin())
RuntimeError: The size of tensor a (1281) must match the size of tensor b (1280) at non-singleton dimension 2 
```

That's because the sparse attention implementations (in contrast to the full attention) [pad](https://github.com/lucidrains/DALLE-pytorch/blob/main/dalle_pytorch/attention.py#L124) the sequence to `text_seq_len + image_seq_len + 1`, while the rotary embeddings are only available for `text_seq_len + image_seq_len` tokens.

If we fix that, we'll get another error:

```python
  File "/home/hivemind/dalle/dalle-pytorch/dalle_pytorch/attention.py", line 35, in <lambda>
    return tuple(map(lambda t: apply_rotary_emb(pos_emb, t), qkv))
  File "/home/hivemind/anaconda3/envs/dalle/lib/python3.8/site-packages/rotary_embedding_torch/rotary_embedding_torch.py", line 46, in apply_rotary_emb
    return torch.cat((t_left, t, t_right), dim = -1)
RuntimeError: Tensors must have same number of dimensions: got 3 and 4
```

That's because the sparse attention implementations [rearrange](https://github.com/lucidrains/DALLE-pytorch/blob/main/dalle_pytorch/attention.py#L130) the q, k, v tensors to 3 dimensions (instead of 4, as in the full attention).

Fixing that leads to the final diff presented in this PR :) It is tested with both full and sparse attention implementations.