### PR TITLE
Add options for weight sharing

### DIFF
--- a/dalle_pytorch/attention.py
+++ b/dalle_pytorch/attention.py
@@ -132,7 +132,7 @@ class SparseConvCausalAttention(nn.Module):
         if exists(rotary_pos_emb):
             q, k, v = apply_pos_emb(rotary_pos_emb, (q, k, v))
 
-        q *= self.scale
+        q = q * self.scale
 
         ((q_text, q_img), (k_text, k_img), (v_text, v_img)) = map(lambda t: (t[:, :-img_seq_len], t[:, -img_seq_len:]), (q, k, v))
 
@@ -252,7 +252,7 @@ class SparseAxialCausalAttention(nn.Module):
         if exists(rotary_pos_emb):
             q, k, v = apply_pos_emb(rotary_pos_emb, (q, k, v))
 
-        q *= self.scale
+        q = q * self.scale
 
         ((q_text, q_img), (k_text, k_img), (v_text, v_img)) = map(lambda t: (t[:, :-img_seq_len], t[:, -img_seq_len:]), (q, k, v))
 

--- a/dalle_pytorch/attention.py
+++ b/dalle_pytorch/attention.py
@@ -132,7 +132,7 @@ class SparseConvCausalAttention(nn.Module):
         if exists(rotary_pos_emb):
             q, k, v = apply_pos_emb(rotary_pos_emb, (q, k, v))
 
-        q = q * self.scale
+        q *= self.scale
 
         ((q_text, q_img), (k_text, k_img), (v_text, v_img)) = map(lambda t: (t[:, :-img_seq_len], t[:, -img_seq_len:]), (q, k, v))
 
@@ -252,7 +252,7 @@ class SparseAxialCausalAttention(nn.Module):
         if exists(rotary_pos_emb):
             q, k, v = apply_pos_emb(rotary_pos_emb, (q, k, v))
 
-        q = q * self.scale
+        q *= self.scale
 
         ((q_text, q_img), (k_text, k_img), (v_text, v_img)) = map(lambda t: (t[:, :-img_seq_len], t[:, -img_seq_len:]), (q, k, v))
 

--- a/dalle_pytorch/dalle_pytorch.py
+++ b/dalle_pytorch/dalle_pytorch.py
@@ -339,7 +339,9 @@ class DALLE(nn.Module):
         stable = False,
         sandwich_norm = False,
         shift_tokens = True,
-        rotary_emb = True
+        rotary_emb = True,
+        shared_attn_ids = None,
+        shared_ff_ids = None,
     ):
         super().__init__()
         assert isinstance(vae, (DiscreteVAE, OpenAIDiscreteVAE, VQGanVAE)), 'vae must be an instance of DiscreteVAE'
@@ -387,7 +389,9 @@ class DALLE(nn.Module):
             stable = stable,
             sandwich_norm = sandwich_norm,
             shift_tokens = shift_tokens,
-            rotary_emb = rotary_emb
+            rotary_emb = rotary_emb,
+            shared_attn_ids = shared_attn_ids,
+            shared_ff_ids = shared_ff_ids,
         )
 
         self.stable = stable
@@ -430,7 +434,7 @@ class DALLE(nn.Module):
             text_tokens = torch.tensor([[0]]).cuda()
         else:
             text_tokens = torch.tensor(tokenizer.tokenizer.encode(text)).cuda().unsqueeze(0)
-   
+
         for _ in range(text_tokens.shape[1], text_seq_len):
             device = text_tokens.device
 
@@ -457,7 +461,7 @@ class DALLE(nn.Module):
             sample = gumbel_sample(filtered_logits, temperature = temperature, dim = -1)
 
             text_tokens = torch.cat((text_tokens, sample[:, None]), dim=-1)
-    
+
         padding_tokens = set(np.arange(self.text_seq_len) + (self.num_text_tokens - self.text_seq_len))
         texts = [tokenizer.tokenizer.decode(text_token, pad_tokens=padding_tokens) for text_token in text_tokens]
         return text_tokens, texts

--- a/dalle_pytorch/dalle_pytorch.py
+++ b/dalle_pytorch/dalle_pytorch.py
@@ -68,6 +68,20 @@ def top_k(logits, thres = 0.5):
     probs.scatter_(1, ind, val)
     return probs
 
+class SharedEmbedding(nn.Embedding):
+    def __init__(self, linear, start_index, end_index, **kwargs):
+        super().__init__(end_index - start_index, linear.weight.shape[1], **kwargs)
+        del self.weight
+
+        self.linear = linear
+        self.start_index = start_index
+        self.end_index = end_index
+
+    def forward(self, input):
+        return F.embedding(
+            input, self.linear.weight[self.start_index:self.end_index], self.padding_idx, self.max_norm,
+            self.norm_type, self.scale_grad_by_freq, self.sparse)
+
 # discrete vae class
 
 class ResBlock(nn.Module):
@@ -318,7 +332,6 @@ class CLIP(nn.Module):
         return loss
 
 # main DALL-E class
-
 class DALLE(nn.Module):
     def __init__(
         self,
@@ -342,6 +355,7 @@ class DALLE(nn.Module):
         rotary_emb = True,
         shared_attn_ids = None,
         shared_ff_ids = None,
+        share_input_output_emb = False,
     ):
         super().__init__()
         assert isinstance(vae, (DiscreteVAE, OpenAIDiscreteVAE, VQGanVAE)), 'vae must be an instance of DiscreteVAE'
@@ -352,9 +366,6 @@ class DALLE(nn.Module):
         image_seq_len = image_fmap_size ** 2
 
         num_text_tokens = num_text_tokens + text_seq_len  # reserve unique padding tokens for each position (text seq len)
-
-        self.text_emb = nn.Embedding(num_text_tokens, dim)
-        self.image_emb = nn.Embedding(num_image_tokens, dim)
 
         self.text_pos_emb = nn.Embedding(text_seq_len + 1, dim) if not rotary_emb else always(0) # +1 for <bos>
         self.image_pos_emb = AxialPositionalEmbedding(dim, axial_shape = (image_fmap_size, image_fmap_size)) if not rotary_emb else always(0)
@@ -403,6 +414,13 @@ class DALLE(nn.Module):
             nn.LayerNorm(dim),
             nn.Linear(dim, self.total_tokens),
         )
+
+        if share_input_output_emb:
+            self.text_emb = SharedEmbedding(self.to_logits[1], 0, num_text_tokens)
+            self.image_emb = SharedEmbedding(self.to_logits[1], num_text_tokens, total_tokens)
+        else:
+            self.text_emb = nn.Embedding(num_text_tokens, dim)
+            self.image_emb = nn.Embedding(num_image_tokens, dim)
 
         seq_range = torch.arange(seq_len)
         logits_range = torch.arange(total_tokens)

--- a/dalle_pytorch/dalle_pytorch.py
+++ b/dalle_pytorch/dalle_pytorch.py
@@ -332,6 +332,7 @@ class CLIP(nn.Module):
         return loss
 
 # main DALL-E class
+
 class DALLE(nn.Module):
     def __init__(
         self,

--- a/dalle_pytorch/transformer.py
+++ b/dalle_pytorch/transformer.py
@@ -155,7 +155,9 @@ class Transformer(nn.Module):
         stable = False,
         sandwich_norm = False,
         shift_tokens = False,
-        rotary_emb = True
+        rotary_emb = True,
+        shared_attn_ids = None,
+        shared_ff_ids = None,
     ):
         super().__init__()
         layers = nn.ModuleList([])
@@ -165,7 +167,13 @@ class Transformer(nn.Module):
         attn_types = cast_tuple(attn_types)
         attn_type_layer = islice(cycle(attn_types), depth)
 
-        for ind, sparse_attn, attn_type in zip(range(depth), sparse_layer, attn_type_layer):
+        shared_attn_ids = cycle(default(shared_attn_ids, range(depth)))
+        shared_ff_ids = cycle(default(shared_ff_ids, range(depth)))
+        shared_attn_layers = {}
+        shared_ff_layers = {}
+
+        for (ind, sparse_attn, attn_type, attn_id, ff_id) in \
+                zip(range(depth), sparse_layer, attn_type_layer, shared_attn_ids, shared_ff_ids):
             if attn_type == 'full':
                 attn_class = partial(Attention, stable = stable)
             elif attn_type == 'sparse':
@@ -181,12 +189,20 @@ class Transformer(nn.Module):
             else:
                 raise ValueError(f'attention type "{attn_type}" is not valid')
 
-            if attn_type != 'mlp':
-                attn = attn_class(dim, causal = causal, seq_len = seq_len, heads = heads, dim_head = dim_head, dropout = attn_dropout)
+            attn = shared_attn_layers.get(attn_id)
+            if not exists(attn):
+                if attn_type != 'mlp':
+                    attn = attn_class(dim, causal = causal, seq_len = seq_len, heads = heads, dim_head = dim_head, dropout = attn_dropout)
+                else:
+                    attn = attn_class(dim = dim, causal = causal, dim_ff = dim * 4)
+                shared_attn_layers[attn_id] = attn
             else:
-                attn = attn_class(dim = dim, causal = causal, dim_ff = dim * 4)
+                assert isinstance(attn, attn_class), 'attn_types do not match shared_attn_ids'
 
-            ff = FeedForward(dim, mult = ff_mult, dropout = ff_dropout)
+            ff = shared_ff_layers.get(ff_id)
+            if not exists(ff):
+                ff = FeedForward(dim, mult = ff_mult, dropout = ff_dropout)
+                shared_ff_layers[ff_id] = ff
 
             if shift_tokens:
                 attn, ff = map(lambda t: PreShiftToken(t, image_size = image_fmap_size, seq_len = seq_len), (attn, ff))

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -131,6 +131,10 @@ model_group.add_argument('--shift_tokens', help = 'Use the shift tokens feature'
 
 model_group.add_argument('--rotary_emb', help = 'Use rotary embeddings', action = 'store_true')
 
+model_group.add_argument('--shared_attn_ids', default = None, type = str, help = 'Comma separated list of shared attention layer ids. Default: sharing is disabled')
+
+model_group.add_argument('--shared_ff_ids', default = None, type = str, help = 'Comma separated list of shared feed forward layer ids. Default: sharing is disabled')
+
 args = parser.parse_args()
 
 # helpers
@@ -193,6 +197,8 @@ SHIFT_TOKENS = args.shift_tokens
 ROTARY_EMB = args.rotary_emb
 
 ATTN_TYPES = tuple(args.attn_types.split(','))
+SHARED_ATTN_IDS = tuple(args.shared_attn_ids.split(',')) if exists(args.shared_attn_ids) else None
+SHARED_FF_IDS = tuple(args.shared_ff_ids.split(',')) if exists(args.shared_ff_ids) else None
 
 DEEPSPEED_CP_AUX_FILENAME = 'auxiliary.pt'
 
@@ -304,6 +310,8 @@ else:
         stable=STABLE,
         shift_tokens=SHIFT_TOKENS,
         rotary_emb=ROTARY_EMB,
+        shared_attn_ids=SHARED_ATTN_IDS,
+        shared_ff_ids=SHARED_FF_IDS,
     )
     resume_epoch = 0
 
@@ -368,7 +376,7 @@ if ENABLE_WEBDATASET:
         if myimg not in item:
             return False
         return True
-	
+
     w_dataset = wds.WebDataset(DATASET, handler=wds.warn_and_continue)
     filtered_dataset = w_dataset.select(filter_dataset)
     ds = filtered_dataset.map_dict(**image_text_mapping).map_dict(**image_mapping).to_tuple(mycap, myimg).batched(BATCH_SIZE / distr_backend.get_world_size(), partial=True)
@@ -623,7 +631,7 @@ for epoch in range(resume_epoch, EPOCHS):
 
         if i % SAVE_EVERY_N_STEPS == 0:
             save_model(DALLE_OUTPUT_FILE_NAME, epoch=epoch)
-	
+
         if i % 100 == 0 and is_root:
             sample_text = text[:1]
             token_list = sample_text.masked_select(sample_text != 0).tolist()
@@ -651,7 +659,7 @@ for epoch in range(resume_epoch, EPOCHS):
         distr_scheduler.step(avg_loss)
 
     save_model(DALLE_OUTPUT_FILE_NAME, epoch=epoch)
-    
+
     if is_root:
         # save trained model to wandb as an artifact every epoch's end
         save_artifact(model_config, DALLE_OUTPUT_FILE_NAME)

--- a/train_dalle.py
+++ b/train_dalle.py
@@ -135,6 +135,8 @@ model_group.add_argument('--shared_attn_ids', default = None, type = str, help =
 
 model_group.add_argument('--shared_ff_ids', default = None, type = str, help = 'Comma separated list of shared feed forward layer ids. Default: sharing is disabled')
 
+model_group.add_argument('--share_input_output_emb', help = 'Share input and output embeddings', action = 'store_true')
+
 args = parser.parse_args()
 
 # helpers
@@ -199,6 +201,7 @@ ROTARY_EMB = args.rotary_emb
 ATTN_TYPES = tuple(args.attn_types.split(','))
 SHARED_ATTN_IDS = tuple(args.shared_attn_ids.split(',')) if exists(args.shared_attn_ids) else None
 SHARED_FF_IDS = tuple(args.shared_ff_ids.split(',')) if exists(args.shared_ff_ids) else None
+SHARE_INPUT_OUTPUT_EMB = args.share_input_output_emb
 
 DEEPSPEED_CP_AUX_FILENAME = 'auxiliary.pt'
 
@@ -312,6 +315,7 @@ else:
         rotary_emb=ROTARY_EMB,
         shared_attn_ids=SHARED_ATTN_IDS,
         shared_ff_ids=SHARED_FF_IDS,
+        share_input_output_emb=SHARE_INPUT_OUTPUT_EMB,
     )
     resume_epoch = 0
 


### PR DESCRIPTION
### Description

This PR adds options for:

1. Sharing weights across some of the transformer layers. This technique was introduced in the [ALBERT paper](https://arxiv.org/abs/1909.11942). If you want a model with shared weights to match the quality of a model without sharing, you need more compute but less parameters. Thus, it is a way to **trade extra computations for reduced GPU memory consumption and reduced communication between GPUs** (in case of distributed training).

2. Sharing weights for input and output embeddings. This technique is commonly used in seq2seq models. For example, there is the `--share-input-output-embed` option in [fairseq](https://fairseq.readthedocs.io/en/v0.7.0/models.html#module-fairseq.models.transformer).

### Experiments

Originally, I've implemented this for [our project](https://training-transformers-together.github.io/) where we train a DALL-E-like model collaboratively over the Internet on LAION-400M.

We use both options above in a model with the following config:

```python
depth = 64
attn_types = list(islice(cycle(['axial_row', 'axial_col', 'axial_row', 'axial_row']), depth - 1))
attn_types.append('conv_like')  # attn_types as in the DALL-E paper
shared_layer_ids = list(islice(cycle(range(4)), depth - 1))
shared_layer_ids.append('w_conv')
dalle = DALLE(
    vae=vqgan_f8,
    num_text_tokens=32100,
    text_seq_len=256,
    dim=1024,
    depth=depth,
    heads=16,
    dim_head=64,
    attn_types=attn_types,
    ff_dropout=0,
    attn_dropout=0,
    shared_attn_ids=shared_layer_ids,
    shared_ff_ids=shared_layer_ids,
    rotary_emb=True,
    reversible=True,
    share_input_output_emb=True,
)
```

The model demonstrates reasonable outputs, so we can indeed use weight sharing for DALL-E in practice. These pictures are generated after passing 1/3 of the training schedule:

<img src="https://user-images.githubusercontent.com/8748943/148812650-d227e1e6-3d33-4344-a97a-124d7bcfe06c.png" width=600>
<img src="https://user-images.githubusercontent.com/8748943/148812671-d038f9e8-64eb-4644-8b05-c747d3ae9eb1.png" width=600>
