### PR TITLE
[Bug Fix]: Remove unsupported 'range' argument in `make_grid`

### DIFF
--- a/train_vae.py
+++ b/train_vae.py
@@ -259,7 +259,7 @@ for epoch in range(EPOCHS):
 
                 images, recons = map(lambda t: t[:k], (images, recons))
                 images, recons, hard_recons, codes = map(lambda t: t.detach().cpu(), (images, recons, hard_recons, codes))
-                images, recons, hard_recons = map(lambda t: make_grid(t.float(), nrow = int(sqrt(k)), normalize = True, range = (-1, 1)), (images, recons, hard_recons))
+                images, recons, hard_recons = map(lambda t: make_grid(t.float(), nrow = int(sqrt(k)), normalize = True), (images, recons, hard_recons))
 
                 logs = {
                     **logs,


### PR DESCRIPTION
 In the latest version of ` torchvision.utils`, the `make_grid` function in does not accept `range` as an argument. This PR fixes the issue found below:
 
 ```
 Traceback (most recent call last):
  File "/home/nathan/new/DALLE-pytorch/train_vae.py", line 262, in <module>
    images, recons, hard_recons = map(lambda t: make_grid(t.float(), nrow = int(sqrt(k)), normalize = True, range = (-1, 1)), (images, recons, hard_recons))
  File "/home/nathan/new/DALLE-pytorch/train_vae.py", line 262, in <lambda>
    images, recons, hard_recons = map(lambda t: make_grid(t.float(), nrow = int(sqrt(k)), normalize = True, range = (-1, 1)), (images, recons, hard_recons))
  File "/home/nathan/.local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
TypeError: make_grid() got an unexpected keyword argument 'range'
Traceback (most recent call last):
  File "/home/nathan/new/DALLE-pytorch/train_vae.py", line 262, in <module>
    images, recons, hard_recons = map(lambda t: make_grid(t.float(), nrow = int(sqrt(k)), normalize = True, range = (-1, 1)), (images, recons, hard_recons))
  File "/home/nathan/new/DALLE-pytorch/train_vae.py", line 262, in <lambda>
    images, recons, hard_recons = map(lambda t: make_grid(t.float(), nrow = int(sqrt(k)), normalize = True, range = (-1, 1)), (images, recons, hard_recons))
  File "/home/nathan/.local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
TypeError: make_grid() got an unexpected keyword argument 'range'
```